### PR TITLE
Add nltk python module to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 pandas
+nltk


### PR DESCRIPTION
For the work we are doing in CTAWG we will need the Natural Language Tool Kit (NLTK) python module.